### PR TITLE
Add workaround for mount folders in Linux guest

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Quick fix to enable vbguest on VirtualBox 4.3.10
+# See https://github.com/mitchellh/vagrant/issues/3341
+if [ ! -e /usr/lib/VBoxGuestAdditions ]; then
+    sudo ln -s /opt/VBoxGuestAdditions-4.3.10/lib/VBoxGuestAdditions \
+	/usr/lib/VBoxGuestAdditions || true
+fi
+
 sudo apt-get update
 
 # NOTE: If kernel is upgraded, you need to upgrade VirtualBox Guest Additions as well


### PR DESCRIPTION
See https://github.com/mitchellh/vagrant/issues/3341

This should fix a known issue of VirtualBox 4.3.10

```
Failed to mount folders in Linux guest. This is usually because
the "vboxsf" file system is not available. Please verify that
the guest additions are properly installed in the guest and
can work properly. The command attempted was:

mount -t vboxsf -o uid=`id -u vagrant`,gid=`getent group vagrant | cut -d: -f3` /vagrant /vagrant
mount -t vboxsf -o uid=`id -u vagrant`,gid=`id -g vagrant` /vagrant /vagrant
```

Signed-off-by: Gianpaolo Macario gmacario@gmail.com
