### PR TITLE
Replace d.image with `gmacario/baseimage`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define "default" do |v|
     v.vm.provider "docker" do |d|
       d.cmd     = ["/sbin/my_init", "--enable-insecure-key"]
-      d.image   = "phusion/baseimage"
+      d.image   = "gmacario/baseimage"
       d.has_ssh = true
     end
     v.vm.provider "docker" do |d, override|


### PR DESCRIPTION
Upstream Docker image `phusion/baseimage` does not contain directory
`/usr/lib/x86_64-linux-gnu/lxc`

which triggers Bug https://github.com/gmacario/vagrant-ubuntu1404/issues/8

Signed-off-by: Gianpaolo Macario gmacario@gmail.com
