### PR TITLE
Do not overrride.ssh.username

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,7 +31,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       d.has_ssh = true
     end
     v.vm.provider "docker" do |d, override|
-      override.ssh.username = "root"
+      # override.ssh.username = "root"
       override.ssh.private_key_path = "phusion.key"
     end
     # v.vm.provision "shell", inline: "echo Hello"


### PR DESCRIPTION
You may keep the default user (vagrant) as long
as you use Docker image "gmacario/baseimage:0.9.15b".

Leave option overrid.ssh.username="root" commented out
in case you want to test other Docker images
which may not have user "vagrant" and phusion insecure key.

Signed-off-by: Gianpaolo Macario gmacario@gmail.com
