### PR TITLE
Switch to d.image="gmacario/baseimage:0.9.15"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.vm.provider "docker" do |d|
       # Additional Docker provider configuration
       # See https://docs.vagrantup.com/v2/docker/configuration.html
-      d.image   = "gmacario/baseimage"
+      d.image   = "gmacario/baseimage:0.9.15"
       d.cmd     = ["/sbin/my_init", "--enable-insecure-key"]
       d.create_args = [
         #"--lxc-conf=\"lxc.network.hwaddr=aa:bb:cc:dd:ee:ff\"",
@@ -31,7 +31,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       d.has_ssh = true
     end
     v.vm.provider "docker" do |d, override|
-      override.ssh.username = "root"
+      #override.ssh.username = "root"
       override.ssh.private_key_path = "phusion.key"
     end
     #v.vm.provision "shell", inline: "echo Hello"


### PR DESCRIPTION
Docker image gmacario/baseimage:0.9.15 includes user "vagrant"
WARNING: locally built image, not yet available at https://registry.hub.docker.com/

Signed-off-by: Gianpaolo Macario gmacario@gmail.com
